### PR TITLE
Move Shortcuts: remove set/deselect options from move menu

### DIFF
--- a/src/common/offsetsUS.asm
+++ b/src/common/offsetsUS.asm
@@ -46,6 +46,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 .definelabel EU_2004868, 0x2004868
 .definelabel EU_201367C, 0x20135D4
 .definelabel EU_20136A4, 0x20135FC
+.definelabel US_2040FA8, 0x2040FA8
 .definelabel EU_204ADD0, 0x204AA98
 .definelabel EU_204D74C, 0x204D414
 .definelabel EU_204D944, 0x204D60C
@@ -139,6 +140,9 @@ ov_36 equ 0x023A7080 ; Extra overlay
 .definelabel US_23857A4, 0x23857A4
 
 ; overlay_0018.bin
+.definelabel US_238B850, 0x238B850
+.definelabel US_238B864, 0x238B864
+.definelabel US_238B888, 0x238B888
 .definelabel US_238BDC8, 0x238BDC8
 .definelabel US_238BDE0, 0x238BDE0
 .definelabel US_238D3A0, 0x238D3A0

--- a/src/common/offsetsUS.asm
+++ b/src/common/offsetsUS.asm
@@ -21,6 +21,7 @@ ov_29 equ 0x022DC240
 ov_11 equ 0x022DC240
 ov_13 equ 0x0238A140
 ov_31 equ 0x02382820
+ov_18 equ 0x0238A140
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
@@ -136,6 +137,14 @@ ov_36 equ 0x023A7080 ; Extra overlay
 ; overlay_0031.bin
 .definelabel US_2385798, 0x2385798
 .definelabel US_23857A4, 0x23857A4
+
+; overlay_0018.bin
+.definelabel US_238BDC8, 0x238BDC8
+.definelabel US_238BDE0, 0x238BDE0
+.definelabel US_238D3A0, 0x238D3A0
+.definelabel US_238D3F8, 0x238D3F8
+.definelabel US_238D440, 0x238D440
+
 
 ; Functions
 	; arm9.bin

--- a/src/common/offsetsUS.asm
+++ b/src/common/offsetsUS.asm
@@ -20,6 +20,7 @@ arm9 equ 0x02000000
 ov_29 equ 0x022DC240
 ov_11 equ 0x022DC240
 ov_13 equ 0x0238A140
+ov_31 equ 0x02382820
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
@@ -131,6 +132,10 @@ ov_36 equ 0x023A7080 ; Extra overlay
 .definelabel EU_234C2FC, 0x234B6FC
 .definelabel EU_234DAF0, 0x234CEF0
 .definelabel EU_2354138, 0x2353538
+
+; overlay_0031.bin
+.definelabel US_2385798, 0x2385798
+.definelabel US_23857A4, 0x23857A4
 
 ; Functions
 	; arm9.bin

--- a/src/moveShortcuts.asm
+++ b/src/moveShortcuts.asm
@@ -213,6 +213,23 @@ afterShortcuts:
 ; Remove "Set move"/"Deselect" options from Electivire menus
 ; -----------------
 .open "overlay_0018.bin", ov_18
+.org US_238B850
+	ldr r5,[r1]
+	add r5,r5,300h
+	ldrsh r0,[r5,8Ch]
+.org US_238B864
+	beq . + 1Ch 
+	subne r5,r5,1h
+	bl US_2040FA8
+	cmp r0,0h
+	ldrne r4,[pc,564h]
+	ldreq r4,[pc,564h]
+	b . + 8h
+	ldr r4,[pc,560h]
+.org US_238B888
+	mov r0,r0
+	mov r1,r2
+	add r5,r5,94h
 .org US_238BDC8
 	.word US_238D3A0
 .org US_238BDE0

--- a/src/moveShortcuts.asm
+++ b/src/moveShortcuts.asm
@@ -210,6 +210,17 @@ afterShortcuts:
 .close
 
 ; -----------------
+; Remove "Set move"/"Deselect" options from Electivire menus
+; -----------------
+.open "overlay_0018.bin", ov_18
+.org US_238BDC8
+	.word US_238D3A0
+.org US_238BDE0
+	.word US_238D440
+	.word US_238D3F8
+.close
+
+; -----------------
 ; Patch: Show a button icon next to the move names indicating which button each move is associated with
 ; (replaces the checkmark that used to indicate that a move was set)
 ; -----------------

--- a/src/moveShortcuts.asm
+++ b/src/moveShortcuts.asm
@@ -198,6 +198,18 @@ afterShortcuts:
 .close
 
 ; -----------------
+; Remove "Set"/"Deselect" options from move menu
+; -----------------
+.open "overlay_0031.bin", ov_31
+.org US_2385798
+	mov r0,r0
+	mov r0,r0
+.org US_23857A4
+	mov r0,r0
+	mov r0,r0
+.close
+
+; -----------------
 ; Patch: Show a button icon next to the move names indicating which button each move is associated with
 ; (replaces the checkmark that used to indicate that a move was set)
 ; -----------------


### PR DESCRIPTION
sorry, i don't know the relevant offsets for the eu version.

this removes the set/deselect options for moves because they no longer do anything once the patch is applied