### PR TITLE
ExtraSpace: Load overlay36 earlier

### DIFF
--- a/src/ExtraSpace.asm
+++ b/src/ExtraSpace.asm
@@ -203,7 +203,7 @@ SKIP_Y9 equ 0
 @ov36AlreadyLoaded:
 	.word 0 ; Set to 1 after loading our extra overlay. Has to be a word so we can directly load it with an ldr.
 @loadOverlay36:
-	sub sp,sp,10h
+	push lr
 	; Set the overlay loaded byte
 	mov r0,1h
 	str r0,[@ov36AlreadyLoaded]
@@ -219,25 +219,26 @@ SKIP_Y9 equ 0
 	; Load the overlay and continue to the end of the function
 	bl @loadOverlay
 
-	add sp,sp,10h
+	; Original instruction
+	mov r0, 0h
 
-	; Call the original function
-	b fn_TaskProcBoot
+	pop pc
 .endarea
 
 ; -----------------
-; This hook was used in the previous version of the patch, the overlay
-; no longer needs to be loaded here
+; These hooks were used in the previous version of the patch,
+; restore the original instructions
 ; -----------------
 .org EU_20042A8
-	blne @loadOverlay ; Previous version: bne @loadOverlay36
+	bne EU_20047A0 
 .org EU_20042B4
-	bl @loadOverlay   ; Previous version: b @loadOverlay36
+	b EU_20047A0
 
 ; -----------------
-; Hook the call to `TaskProcBoot`
+; Hook inside `NitroMain`, which is pretty early in the game's
+; initialization process
 ; -----------------
-.org EU_2000DC0
+.org fn_NitroMain+34h
 	bl @loadOverlay36
 .close
 

--- a/src/ExtraSpace.asm
+++ b/src/ExtraSpace.asm
@@ -216,7 +216,6 @@ SKIP_Y9 equ 0
 	; If something went wrong, call the fallback function first
 	moveq r0,1h
 	bleq fn_loadOverlayFallback
-	; Load the overlay and continue to the end of the function
 	bl @loadOverlay
 
 	; Original instruction
@@ -230,7 +229,7 @@ SKIP_Y9 equ 0
 ; restore the original instructions
 ; -----------------
 .org EU_20042A8
-	bne EU_20047A0 
+	bne EU_20047A0
 .org EU_20042B4
 	b EU_20047A0
 

--- a/src/common/offsetsEU.asm
+++ b/src/common/offsetsEU.asm
@@ -23,7 +23,6 @@ ov_13 equ 0x0238AC80
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
-.definelabel EU_2000DC0, 0x2000DC0
 .definelabel EU_2001238, 0x2001238
 .definelabel EU_20015DC, 0x20015DC
 .definelabel EU_2002E98, 0x2002E98
@@ -138,7 +137,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 
 ; Functions
 	; arm9.bin
-	.definelabel fn_TaskProcBoot,               0x2003328
+	.definelabel fn_NitroMain,                  0x2000C6C
 	.definelabel fn_loadOverlayFallback,        0x2003D2C
 	.definelabel fn_EU_2008194,                 0x2008194
 	.definelabel fn_EU_2013AF8,                 0x2013AF8

--- a/src/common/offsetsEU.asm
+++ b/src/common/offsetsEU.asm
@@ -23,6 +23,7 @@ ov_13 equ 0x0238AC80
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
+.definelabel EU_2000DC0, 0x2000DC0
 .definelabel EU_2001238, 0x2001238
 .definelabel EU_20015DC, 0x20015DC
 .definelabel EU_2002E98, 0x2002E98
@@ -137,6 +138,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 
 ; Functions
 	; arm9.bin
+	.definelabel fn_TaskProcBoot,               0x2003328
 	.definelabel fn_loadOverlayFallback,        0x2003D2C
 	.definelabel fn_EU_2008194,                 0x2008194
 	.definelabel fn_EU_2013AF8,                 0x2013AF8

--- a/src/common/offsetsJP.asm
+++ b/src/common/offsetsJP.asm
@@ -23,7 +23,6 @@ ov_13 equ 0x0238B6A0
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
-.definelabel EU_2000DC0, 0x2000DC0
 .definelabel EU_2001238, 0x2001238
 .definelabel EU_20015DC, 0x20015DC
 .definelabel EU_2002E98, 0x2002E98
@@ -138,7 +137,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 
 ; Functions
 	; arm9.bin
-	.definelabel fn_TaskProcBoot,               0x2003328
+	.definelabel fn_NitroMain,                  0x2000C6C
 	.definelabel fn_loadOverlayFallback,        0x2003D2C
 	.definelabel fn_EU_2008194,                 0x2008194
 	.definelabel fn_EU_2013AF8,                 0x2013A20

--- a/src/common/offsetsJP.asm
+++ b/src/common/offsetsJP.asm
@@ -23,6 +23,7 @@ ov_13 equ 0x0238B6A0
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
+.definelabel EU_2000DC0, 0x2000DC0
 .definelabel EU_2001238, 0x2001238
 .definelabel EU_20015DC, 0x20015DC
 .definelabel EU_2002E98, 0x2002E98
@@ -137,6 +138,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 
 ; Functions
 	; arm9.bin
+	.definelabel fn_TaskProcBoot,               0x2003328
 	.definelabel fn_loadOverlayFallback,        0x2003D2C
 	.definelabel fn_EU_2008194,                 0x2008194
 	.definelabel fn_EU_2013AF8,                 0x2013A20

--- a/src/common/offsetsUS.asm
+++ b/src/common/offsetsUS.asm
@@ -23,6 +23,7 @@ ov_13 equ 0x0238A140
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
+.definelabel EU_2000DC0, 0x2000DC0
 .definelabel EU_2001238, 0x2001238
 .definelabel EU_20015DC, 0x20015DC
 .definelabel EU_2002E98, 0x2002E98
@@ -137,6 +138,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 
 ; Functions
 	; arm9.bin
+	.definelabel fn_TaskProcBoot,               0x2003328
 	.definelabel fn_loadOverlayFallback,        0x2003D2C
 	.definelabel fn_EU_2008194,                 0x2008194
 	.definelabel fn_EU_2013AF8,                 0x2013A50

--- a/src/common/offsetsUS.asm
+++ b/src/common/offsetsUS.asm
@@ -23,7 +23,6 @@ ov_13 equ 0x0238A140
 ov_36 equ 0x023A7080 ; Extra overlay
 
 ; arm9.bin
-.definelabel EU_2000DC0, 0x2000DC0
 .definelabel EU_2001238, 0x2001238
 .definelabel EU_20015DC, 0x20015DC
 .definelabel EU_2002E98, 0x2002E98
@@ -138,7 +137,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 
 ; Functions
 	; arm9.bin
-	.definelabel fn_TaskProcBoot,               0x2003328
+	.definelabel fn_NitroMain,                  0x2000C6C
 	.definelabel fn_loadOverlayFallback,        0x2003D2C
 	.definelabel fn_EU_2008194,                 0x2008194
 	.definelabel fn_EU_2013AF8,                 0x2013A50


### PR DESCRIPTION
Loads the custom overlay before `TaskProcBoot` is called. It was previously loaded after the first regular overlay load.