### PR TITLE
FixNo$GbaSaves 0.2.0

### DIFF
--- a/src/FixNo$GbaSaves.asm
+++ b/src/FixNo$GbaSaves.asm
@@ -1,5 +1,5 @@
 ; ----------------------------------------------------------------------
-; Copyright © 2022 Frostbyte0x70
+; Copyright © 2024 Frostbyte0x70
 ; 
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
@@ -18,17 +18,48 @@
 ; This patch fixes an issue that causes saving to fail on the No$GBA emulator
 
 ; This file is intended to be used with armips v0.11
+; The patch "ExtraSpace.asm" must be applied before this one
 ; Required ROM: Explorers of Sky (EU/US/JP)
-; Required files: arm9.bin
+; Required files: arm9.bin, overlay_0036.bin
 
 .nds
 .include "common/regionSelect.asm"
 
+.open "overlay_0036.bin", ov_36
+.orga 0x1BA0
+.area 0x54
+NoCashHookOne:
+    push r14
+    bl NoCashCheck
+    movne r0,#0x8 ; vanilla code for if NOT on no$
+    moveq r0,#0x7 ; modified code for if on no$
+    pop r15
+
+NoCashHookTwo:
+    push r14
+    bl NoCashCheck
+    ldrne r0,=0x203F ; vanilla value for if NOT on no$
+    ldreq r0,=0x20BF ; modified value for if on no$
+    pop r15
+
+NoCashCheck:
+    push r1,r2
+    ldr r1,=0x4FFFA00 ; No$GBA writes the string "no$gba <version number>" to this address for debugging purposes. this patch checks for that string to determine if we're running on no$.
+    ldr r1,[r1]
+    ldr r2,0x67246F6E ; ASCII for "no$g"
+    cmp r1,r2
+    pop r1,r2
+    bx lr
+.pool
+.endarea
+
+.close
+
 .open "arm9.bin", arm9
 .org EU_204ADD0
-	mov r0,7h
-	
-.org EU_2083BA4
-.byte 0xBF
+    bl NoCashHookOne
+
+.org EU_208385C
+   bl NoCashHookTwo
 
 .close

--- a/src/FixNo$GbaSaves.asm
+++ b/src/FixNo$GbaSaves.asm
@@ -46,7 +46,7 @@ NoCashCheck:
     push r1,r2
     ldr r1,=0x4FFFA00 ; No$GBA writes the string "no$gba <version number>" to this address for debugging purposes. this patch checks for that string to determine if we're running on no$.
     ldr r1,[r1]
-    ldr r2,0x67246F6E ; ASCII for "no$g"
+    ldr r2,=0x67246F6E ; ASCII for "no$g"
     cmp r1,r2
     pop r1,r2
     bx lr

--- a/src/common/offsetsEU.asm
+++ b/src/common/offsetsEU.asm
@@ -63,7 +63,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 .definelabel EU_20592A0, 0x20592A0
 .definelabel EU_20592B0, 0x20592B0
 .definelabel EU_205931C, 0x205931C
-.definelabel EU_2083BA4, 0x2083BA4
+.definelabel EU_208385C, 0x208385C
 .definelabel EU_20928F0, 0x20928F0
 .definelabel EU_2092938, 0x2092938
 .definelabel EU_209CE8C, 0x209CE8C

--- a/src/common/offsetsJP.asm
+++ b/src/common/offsetsJP.asm
@@ -63,7 +63,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 .definelabel EU_20592A0, 0x2059220
 .definelabel EU_20592B0, 0x2059230
 .definelabel EU_205931C, 0x205929C
-.definelabel EU_2083BA4, 0x2083AF4
+.definelabel EU_208385C, 0x20837AC
 .definelabel EU_20928F0, 0x2092840
 .definelabel EU_2092938, 0x2092888
 .definelabel EU_209CE8C, 0x209DD24

--- a/src/common/offsetsUS.asm
+++ b/src/common/offsetsUS.asm
@@ -63,7 +63,7 @@ ov_36 equ 0x023A7080 ; Extra overlay
 .definelabel EU_20592A0, 0x2058F24
 .definelabel EU_20592B0, 0x2058F34
 .definelabel EU_205931C, 0x2058FA0
-.definelabel EU_2083BA4, 0x208380C
+.definelabel EU_208385C, 0x20834C4
 .definelabel EU_20928F0, 0x2092558
 .definelabel EU_2092938, 0x20925A0
 .definelabel EU_209CE8C, 0x209C950


### PR DESCRIPTION
FixNo$GbaSaves no longer breaks saving on melonDS.
Related: https://github.com/SkyTemple/skytemple-files/pull/556